### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
+          cache: 'pnpm'
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - name: Build site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,14 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
-          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
+      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - name: Build site
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build site
+        env:
+          # GitHub Actions sets this automatically. It allows Next.js to
+          # compute the correct basePath and assetPrefix for GitHub Pages.
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: pnpm build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Variable Transit
+
+This project is a [Next.js](https://nextjs.org/) application configured for static export so it can be hosted on **GitHub Pages**.
+
+## Local development
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Build and preview the static site
+
+```bash
+# Generates the static site in the `out` directory
+pnpm build
+npx serve out
+```
+
+## Deploy to GitHub Pages
+
+1. Push the repository to GitHub.
+2. Ensure GitHub Pages is enabled for the repository (Settings → Pages → Build and deployment → GitHub Actions).
+3. Every push to `main` triggers the [deploy workflow](.github/workflows/deploy.yml) which builds the site and publishes it to GitHub Pages.
+4. After the workflow completes, your site will be available at:
+   `https://<username>.github.io/<repository>/`
+
+For a manual deploy, run `pnpm build` and upload the contents of the `out` directory to any static host.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,35 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  images: {
-    unoptimized: true,
-  },
+const nextConfig = () => {
+  // When building on GitHub Actions, `GITHUB_REPOSITORY` contains
+  // the `owner/repo` slug. We use this to configure a base path so
+  // that the statically exported site works when served from
+  // `https://<user>.github.io/<repo>/`.
+  const repo = process.env.GITHUB_REPOSITORY?.split('/')[1]
+
+  /** @type {import('next').NextConfig} */
+  const config = {
+    eslint: {
+      ignoreDuringBuilds: true,
+    },
+    typescript: {
+      ignoreBuildErrors: true,
+    },
+    images: {
+      unoptimized: true,
+    },
+    // Generate a static site that can be hosted on GitHub Pages.
+    output: 'export',
+    trailingSlash: true,
+  }
+
+  // If the repo name is available (e.g. in GitHub Actions), prefix
+  // asset paths so that static files resolve correctly on GitHub Pages.
+  if (repo) {
+    config.basePath = `/${repo}`
+    config.assetPrefix = `/${repo}/`
+  }
+
+  return config
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- configure Next.js for static export and GitHub Pages paths
- document build and deployment instructions
- add GitHub Actions workflow to publish to GitHub Pages
- install pnpm in the deployment workflow so the build step runs on Actions

## Testing
- `pnpm lint` *(fails: interactive prompt for ESLint configuration)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b12a7de21483208b9caf94ed665cb0